### PR TITLE
Bug fix for Badger::Base

### DIFF
--- a/lib/Badger/Base.pm
+++ b/lib/Badger/Base.pm
@@ -26,7 +26,7 @@ use Badger::Class
     };
 
 use Badger::Exception;              # TODO: autoload
-use Badger::Debug 'debug debug_up';
+use Badger::Debug 'debug debug_up dump_data_inline dump_data dump_list dump_hash';
 
 our $EXCEPTION = 'Badger::Exception' unless defined $EXCEPTION;
 our $ON_WARN   = WARN;


### PR DESCRIPTION
To reproduce:

```
use strict; use warnings;
use lib qw(lib);
use Badger::Debug modules => 'Badger::Base';
use Badger::Base;
my $obj = Badger::Base->new();
$obj->warn('warning fails');
```
