### PR TITLE
perl 5.22 will limit where const subs are created

### DIFF
--- a/lib/Badger/Codecs.pm
+++ b/lib/Badger/Codecs.pm
@@ -146,7 +146,8 @@ sub export_codec {
     # NOTE: I think it's more correct to attempt the export regardless of 
     # any existing sub and allow a redefine warning to be raised.  This is
     # better than silently failing to export the requested items.
-    *{$cmethod} = sub() { $codec }; # unless defined &{$cmethod};
+    my $temp = $codec; # make sure this is a constant on 5.22
+    *{$cmethod} = sub() { $temp };  # unless defined &{$cmethod};
     *{$emethod} = $codec->encoder;  # unless defined &{$emethod};
     *{$dmethod} = $codec->decoder;  # unless defined &{$dmethod};
 }

--- a/lib/Badger/Debug.pm
+++ b/lib/Badger/Debug.pm
@@ -107,7 +107,8 @@ sub _export_debug_constant {
         if defined ${ $target.PKG.DEBUG };
 
     $self->debug("$symbol option setting $target DEBUG to $value\n") if $DEBUG;
-    *{ $target.PKG.DEBUG } = sub () { $value };
+    my $temp = $value; # make sure this is a const sub on 5.22
+    *{ $target.PKG.DEBUG } = sub () { $temp };
 }
 
 


### PR DESCRIPTION
5.21.x (5.22 to be) changes the:

 *foo = sub () { $value }

recipe to only apply where it's purely an optimization, ie. where $value can't be modified by function calls etc.

Due to the limitations of scanning the op-tree this means that $value can really only be initialized as in:

  my $value = somevalue;

which isn't the case for the two cases changed by this pull request.