### PR TITLE
an unescaped { starts a match n times, perl 5.21.x warns about it

### DIFF
--- a/t/core/dump.t
+++ b/t/core/dump.t
@@ -75,4 +75,4 @@ my $tre = My::Badger::Tre->new(
 
 my $text = $tre->dump;
 #print $text;
-like( $text, qr/one => {\s+x => 10,\s+y => 20\s+}/, 'partial dump of one' );
+like( $text, qr/one => \{\s+x => 10,\s+y => 20\s+\}/, 'partial dump of one' );


### PR DESCRIPTION
prevent the warning.