### PR TITLE
ensure perl 5.22 won't warn about format vs argument list mis-matches

### DIFF
--- a/lib/Badger/Utils.pm
+++ b/lib/Badger/Utils.pm
@@ -182,6 +182,7 @@ sub xprintf {
                 ? _xprintf_ifdef(\@args, $1, $2, $3)
                 : '%' . $1 . '$' . ($2 || 's')
         }egx;
+    no if $] > 5.021, warnings => "redundant";
     sprintf($format, @_);
 }
 


### PR DESCRIPTION
You might want to fix the callers rather than applying this patch.