### PR TITLE
definitive_write failure

### DIFF
--- a/lib/Badger/Filesystem.pm
+++ b/lib/Badger/Filesystem.pm
@@ -421,30 +421,29 @@ sub chmod_path {
     my $path = $self->definitive_write(shift);
     chmod(shift, $path);
 }
-    
+
 
 #-----------------------------------------------------------------------
 # file manipulation methods
 #-----------------------------------------------------------------------
 
 sub create_file {
-    my $self = shift;
-    my $path = $self->definitive_write(shift);
-    unless (-e $path) {
-        $self->write_file($path);
+    my ($self, $path) = @_;
+    unless (-e $self->definitive_write($path)) {
+        $self->write_file($path); # calls definitive_write again
     }
     return 1;
 }
 
 sub touch_file {
-    my $self = shift;
-    my $path = $self->definitive_write(shift);
-    if (-e $path) {
+    my ($self, $path) = @_;
+    my $definitive = $self->definitive_write($path);
+    if (-e $definitive) {
         my $now = time();
-        utime $now, $now, $path;
-    } 
+        utime $now, $now, $definitive;
+    }
     else {
-        $self->write_file($path);
+        $self->write_file($path); # calls definitive_write again
     }
 }
 

--- a/t/filesystem/filesystem.t
+++ b/t/filesystem/filesystem.t
@@ -16,8 +16,8 @@ use strict;
 use warnings;
 use File::Spec;
 use Badger::Filesystem 'FS VFS :types :dirs cwd getcwd $Bin Bin';
-use Badger::Test 
-    tests => 59,
+use Badger::Test
+    tests => 62,
     debug => 'Badger::Filesystem',
     args  => \@ARGV;
 
@@ -216,3 +216,70 @@ is( $cwd, $fs->cwd, 'fs->cwd matches in the other other way' );
 is( $fs->merge_paths('/path/one', '/path/two'), lp '/path/one/path/two', 'merged abs paths' );
 is( $fs->merge_paths('/path/one', 'path/two'), lp '/path/one/path/two', 'merged abs/rel paths' );
 is( $fs->merge_paths('path/one', 'path/two'), lp 'path/one/path/two', 'merged rel/rel paths' );
+
+#-----------------------------------------------------------------------
+# definitive* should not be applied multiple times when creating file
+#-----------------------------------------------------------------------
+
+package DFS;
+
+use Badger::Class base => 'Badger::Filesystem';
+
+sub definitive_write {
+  my $self = shift;
+  my $candidate = $self->SUPER::definitive_write(@_);
+  return "$candidate-X";
+}
+
+{
+  no warnings;             # avoid warnings about names used only once
+  *definitive = \&definitive_write;
+  *definitive_read = \&definitive_write;
+}
+
+package main;
+
+my $dfs = DFS->new;
+my $filename = 'foo-create.txt';
+$path = "testfiles/$filename";
+$abs = $dfs->absolute($path);
+my $def = $dfs->definitive_write($path);
+is($def, "$abs-X", 'definitive_write');
+$file1 = $dfs->file($path);
+ok($file1, "fetched $path");
+is($file1->name, $filename, "file object has non-definitive name");
+ok($file1->create, "call create on $path");
+unless (ok(-e $def, "definitive file $path-X exists")) {
+  my @files = grep { /$filename/ } FS->directory('testfiles')->files;
+  fail("Instead found @files") if @files;
+}
+
+$filename = 'foo-touch.txt';
+$path = "testfiles/$filename";
+$abs = $dfs->absolute($path);
+$def = $dfs->definitive_write($path);
+is($def, "$abs-X", 'definitive_write');
+$file1 = $dfs->file($path);
+ok($file1, "fetched $path");
+is($file1->name, $filename, "file object has non-definitive name");
+ok($file1->touch, "call touch on $path");
+unless (ok(-e $def, "definitive file $path-X exists")) {
+  my @files = grep { /$filename/ } FS->directory('testfiles')->files;
+  fail("Instead found @files") if @files;
+}
+
+$filename = 'foo-open.txt';
+$path = "testfiles/$filename";
+$abs = $dfs->absolute($path);
+$def = $dfs->definitive_write($path);
+is($def, "$abs-X", 'definitive_write');
+$file1 = $dfs->file($path);
+ok($file1, "fetched $path");
+is($file1->name, $filename, "file object has non-definitive name");
+my $fh = $file1->open('w');
+ok($fh, "call open (for write) on $path");
+$fh->close;
+unless (ok(-e $def, "definitive file $path-X exists")) {
+  my @files = grep { /$filename/ } FS->directory('testfiles')->files;
+  fail("Instead found @files") if @files;
+}


### PR DESCRIPTION
`Badger::Filesystem::File::create` and `touch` indirectly call `Badger::Filesystem::definitive_write` twice.  If `definitive_write` (in a class derived from `Badger::Filesystem`) unconditionally modifies the file name, then the created/touched file is not the one intended.  For example, if `definitive_write` appends _-X_ to the file name, then calling create or touch on _file.txt_ creates a file _file.txt-X-X_ instead of the expected _file.txt-X_.

Added a test for this case, and implemented a solution.
