### PR TITLE
Suppress “once” warnings from exporter

### DIFF
--- a/lib/Badger/Exporter.pm
+++ b/lib/Badger/Exporter.pm
@@ -378,6 +378,8 @@ sub export {
 sub exportables {
     my $class = shift;
     no strict REFS;
+    no warnings ONCE;
+
     my $cache = ${ $class.PKG.EXPORTABLES } ||= do {
         my ($pkg, $symbols, %done, @all, %any, %tags, %hooks, @fails, @before, @after);
         my @pending = ($class);


### PR DESCRIPTION
perl 5.26.0 generates lots of extra warnings within the exporter.

Fixes #13 