### PR TITLE
merge relative paths in VFS on windows without erroring (fixes install on windows)

### DIFF
--- a/lib/Badger/Filesystem.pm
+++ b/lib/Badger/Filesystem.pm
@@ -277,7 +277,7 @@ sub merge_paths {
     my @p2   = $spec->splitpath($path);
 
     # check volumes match
-    if (defined $p2[0]) {
+    if (defined $p2[0] and length $p2[0]) {
         $p1[0] ||= $p2[0];
         return $self->error_msg( bad_volume => $p1[0], $p1[0] )
             unless $p1[0] eq $p2[0];


### PR DESCRIPTION
splitpath on windows results in a defined null-length string for the volume of portion of the path every time. When merging relative paths onto the root path of a VFS, Badger broke because it only checked the volume part for definedness.

This fix allows Badger (and thus its dependencies) to install on Windows again.