### PR TITLE
Fix numerous spelling mistakes in POD

### DIFF
--- a/lib/Badger/Class.pm
+++ b/lib/Badger/Class.pm
@@ -2246,7 +2246,7 @@ C<Badger::Foo::Bar> would return C<foo.bar>.
 
 This method returns C<Badger> by default.  It is used by the L<id()>
 method to determine the common base part of a module name to remove
-when generating an identifer for error reporting.
+when generating an identifier for error reporting.
 
 =head2 instance()
 
@@ -2716,7 +2716,7 @@ for further details
 
 This method can be used to update the C<$MESSAGES> package variable in the
 target class to include the messages passed as arguments, either as a list
-or reference to a hash array of named paramters.
+or reference to a hash array of named parameters.
 
     # define new class message
     class->messages( careful => 'Careful with that %s %s!' );
@@ -3083,7 +3083,7 @@ local precedence order of AB says that A should resolve before B, while the
 LPO of BA says that B should come before A. The C3 algorithm will
 intentionally fail at this point and throw an error warning about an
 inconsistent heterarchy. In contrast, this implementation will resolve A
-before B becase the more specialised ABBA subclass defines AB before BA. AB is
+before B because the more specialised ABBA subclass defines AB before BA. AB is
 the winner that takes it all and BA is the loser standing small.
 
 This implementation was originally written for the C<Template Toolkit> where

--- a/lib/Badger/Constants.pm
+++ b/lib/Badger/Constants.pm
@@ -254,7 +254,7 @@ A regular expression used to match strings containing the C<*> or C<?>
 wildcard characters.
 
     if ($path =~ WILDCARD) {
-        # do someting...
+        # do something...
     } 
 
 =head2 UTF8

--- a/lib/Badger/Exporter.pm
+++ b/lib/Badger/Exporter.pm
@@ -738,7 +738,7 @@ of named parameters and forwards the arguments onto the relevant method(s).
         },
     );
 
-Each key correponds to one of the methods below, specified without the
+Each key corresponds to one of the methods below, specified without the
 C<export_> prefix. e.g. C<all> for L<export_all()>, C<any> for L<export_any()>
 and so on. The method is called with the corresponding value being passed
 as an argument.

--- a/lib/Badger/Filesystem.pm
+++ b/lib/Badger/Filesystem.pm
@@ -931,7 +931,7 @@ against it.
     my $dir  = $fs->dir('/path/to/dir');
 
 Creating an object allows you to define additional configuration parameters
-for the filesystem. There aren't any interesting paramters worth mentioning in
+for the filesystem. There aren't any interesting parameters worth mentioning in
 the base class L<Badger::Filesystem> module at the moment, but subclasses
 (like L<Badger::Filesystem::Virtual>) do use them.
 

--- a/lib/Badger/Filesystem/File.pm
+++ b/lib/Badger/Filesystem/File.pm
@@ -413,7 +413,7 @@ Like L<move_to()> but working in reverse.
 
 =head2 print(@content)
 
-This method concatentates all arguments into a single string which it then
+This method concatenates all arguments into a single string which it then
 forwards to the L<write()> method.  This effectively forces the L<write()>
 method to always write something to the file, even if it's an empty string.
 

--- a/lib/Badger/Filesystem/Path.pm
+++ b/lib/Badger/Filesystem/Path.pm
@@ -396,7 +396,7 @@ sub metadata {
 
 =head1 NAME
 
-Badger::Filesystem::Path - generic fileystem path object
+Badger::Filesystem::Path - generic filesystem path object
 
 =head1 SYNOPSIS
 

--- a/lib/Badger/Filter.pm
+++ b/lib/Badger/Filter.pm
@@ -325,7 +325,7 @@ to be included.
 
 =item *
 
-A string containing a '*' wilcard character, e.g. C<foo/*>.  The star is used
+A string containing a '*' wildcard character, e.g. C<foo/*>.  The star is used
 to represent any sequence of characters.
 
 =item *

--- a/lib/Badger/Hub.pm
+++ b/lib/Badger/Hub.pm
@@ -633,7 +633,7 @@ that it is using.
 This method configures and instantiates a component. The first argument is the
 component name. This is mapped to a module via the L<component()> method and
 the module is loaded. A list of named parameters, or a reference to a hash
-array of named paramters may follow. A reference to the hub is added to these
+array of named parameters may follow. A reference to the hub is added to these
 as the C<hub> item before forwarding them to the constructor method for the
 component.  The component is then cached for subsequent use.
 

--- a/lib/Badger/Prototype.pm
+++ b/lib/Badger/Prototype.pm
@@ -174,8 +174,8 @@ as shown in the earlier example.
         # ...code follows...
     }
 
-If you prefer a more succint idiom and aren't too worried about calling the
-L<prototype> method unneccessarily, then you can write it like this:
+If you prefer a more succinct idiom and aren't too worried about calling the
+L<prototype> method unnecessarily, then you can write it like this:
 
     sub greeting {
         my $self = shift->prototype;

--- a/lib/Badger/URL.pm
+++ b/lib/Badger/URL.pm
@@ -492,7 +492,7 @@ This constructor method is used to create a new URL object.
         'http://abw@badgerpower.com:8080/under/ground?animal=badger#stripe'
     );
 
-You can also specify the individual parts of the URL using named paramters.
+You can also specify the individual parts of the URL using named parameters.
 
     my $url = Badger::URL->new(
         scheme      => 'http',


### PR DESCRIPTION
Hey,

I've packaged Badger for Debian. Our lintian tool picked up a number of spelling mistakes in the POD, this MR fixes those.

Cheers,
Andrew